### PR TITLE
Add transport controls to BASEII

### DIFF
--- a/BASEII.control.js
+++ b/BASEII.control.js
@@ -307,25 +307,31 @@ function setup_modes()
 	{
 		post('channelControlsSub entered');
 		sendSysex(LIVEBUTTONMODE);
-		for(var i=0;i<8;i++)
+		for(var i=0;i<7;i++)
 		{
 			mixer.channelstrip(i)._mute.set_control(grid.get_button(i, 0));
 			mixer.channelstrip(i)._solo.set_control(grid.get_button(i, 1));
 			mixer.channelstrip(i)._arm.set_control(grid.get_button(i, 2));
 			mixer.channelstrip(i)._stop.set_control(grid.get_button(i, 3));
 		}
+		transport._stop.set_control(grid.get_button(7, 0));
+		transport._play.set_control(grid.get_button(7, 1));
+		transport._record.set_control(grid.get_button(7, 2));
 		channelControlsSub.active = true;
 	}
 	channelControlsSub.exit_mode = function()
 	{
 		post('channelControlsSub exit');
-		for(var i=0;i<8;i++)
+		for(var i=0;i<7;i++)
 		{
 			mixer.channelstrip(i)._mute.set_control();
 			mixer.channelstrip(i)._solo.set_control();
 			mixer.channelstrip(i)._arm.set_control();
 			mixer.channelstrip(i)._stop.set_control();
 		}
+		transport._stop.set_control();
+		transport._play.set_control();
+		transport._record.set_control();
 		channelControlsSub.active = false;
 	}
 


### PR DESCRIPTION
When in shift+clip mode set the 8th column of grid buttons to transport controls rather than the 8th mixer channel's controls.
 
This is a feature rather than a bug so feel free to reject it, but I think it's a very useful change. UX-wise it's inline with using the 8th column for 'stop all clips' when you hold down the track selector.